### PR TITLE
Changed extension filter

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -10,7 +10,7 @@ function getModules(){
         
         scriptDir.child("content").walk(e => {
             let path = e.absolutePath();
-            if(e.extension().toLowerCase() !== "js") return;
+            if(String(e.extension()).toLowerCase() !== "js") return;
             if(ignored.includes(e.nameWithoutExtension())) return;
             
             path = path.replace(scriptDir.absolutePath(), "");


### PR DESCRIPTION
Line 13: e.extension() is java.lang.String, not String.

The filter filters everything. Nothing can pass it because of type differences.